### PR TITLE
type safety for callables

### DIFF
--- a/dataclass_mapper/collection.py
+++ b/dataclass_mapper/collection.py
@@ -1,5 +1,7 @@
 from typing import Callable, Dict, Type
 
+from dataclass_mapper.utils import get_class_name
+
 
 class MappingCollection:
     def __init__(self):
@@ -13,7 +15,7 @@ class MappingCollection:
         func = self.storage.get(self.create_func_name(SourceCls, TargetCls))
         if not func:
             raise NotImplementedError(
-                f"Object of type '{SourceCls.__name__}' cannot be mapped to '{TargetCls.__name__}'"
+                f"Object of type '{get_class_name(SourceCls)}' cannot be mapped to '{get_class_name(TargetCls)}'"
             )
         return func
 
@@ -21,7 +23,7 @@ class MappingCollection:
         func = self.storage.get(self.update_func_name(SourceCls, TargetCls))
         if not func:
             raise NotImplementedError(
-                f"Object of type '{SourceCls.__name__}' cannot be mapped to '{TargetCls.__name__}'"
+                f"Object of type '{get_class_name(SourceCls)}' cannot be mapped to '{get_class_name(TargetCls)}'"
             )
         return func
 
@@ -29,7 +31,7 @@ class MappingCollection:
         code = self.code.get(self.create_func_name(SourceCls, TargetCls))
         if not code:
             raise NotImplementedError(
-                f"Object of type '{SourceCls.__name__}' cannot be mapped to '{TargetCls.__name__}'"
+                f"Object of type '{get_class_name(SourceCls)}' cannot be mapped to '{get_class_name(TargetCls)}'"
             )
         return code
 
@@ -37,7 +39,7 @@ class MappingCollection:
         code = self.code.get(self.update_func_name(SourceCls, TargetCls))
         if not code:
             raise NotImplementedError(
-                f"Object of type '{SourceCls.__name__}' cannot be mapped to '{TargetCls.__name__}'"
+                f"Object of type '{get_class_name(SourceCls)}' cannot be mapped to '{get_class_name(TargetCls)}'"
             )
         return code
 
@@ -52,7 +54,8 @@ class MappingCollection:
     ) -> None:
         if self.contains_create(SourceCls, TargetCls):
             raise AttributeError(
-                f"There already exists a mapping between '{SourceCls.__name__}' and '{TargetCls.__name__}'"
+                f"There already exists a mapping between '{get_class_name(SourceCls)}' "
+                f"and '{get_class_name(TargetCls)}'"
             )
         self.storage[self.create_func_name(SourceCls, TargetCls)] = func
         self.code[self.create_func_name(SourceCls, TargetCls)] = code
@@ -64,7 +67,8 @@ class MappingCollection:
     ) -> None:
         if self.contains_update(SourceCls, TargetCls):
             raise AttributeError(
-                f"There already exists a mapping between '{SourceCls.__name__}' and '{TargetCls.__name__}'"
+                f"There already exists a mapping between '{get_class_name(SourceCls)}' "
+                f"and '{get_class_name(TargetCls)}'"
             )
         self.storage[self.update_func_name(SourceCls, TargetCls)] = func
         self.code[self.update_func_name(SourceCls, TargetCls)] = code

--- a/dataclass_mapper/enum.py
+++ b/dataclass_mapper/enum.py
@@ -1,6 +1,8 @@
 from enum import Enum
 from typing import Any, Callable, Dict, Union, cast
 
+from dataclass_mapper.utils import get_class_name
+
 # mapping between source members and target members
 EnumMapping = Dict[Union[str, Enum], Union[str, Enum]]
 
@@ -15,7 +17,7 @@ def member_to_name_and_raise(
 
     raise ValueError(
         f"The mapping key '{member}' must be a member of the {class_description} enum "
-        f"'{enum_cls.__name__}' or a string with its name"
+        f"'{get_class_name(enum_cls)}' or a string with its name"
     )
 
 
@@ -46,7 +48,8 @@ def make_enum_mapper(
             full_mapping[source_member] = target_members[source_member_name]
         else:
             raise ValueError(
-                f"The member '{source_member_name}' of the source enum '{source_cls.__name__}' doesn't have a mapping."
+                f"The member '{source_member_name}' of the source enum "
+                f"'{get_class_name(source_cls)}' doesn't have a mapping."
             )
 
     def convert(self: Any, extra: Dict) -> Any:

--- a/dataclass_mapper/expression_converters/__init__.py
+++ b/dataclass_mapper/expression_converters/__init__.py
@@ -2,7 +2,7 @@ from .anything_to_any import AnythingToAnyExpressionConverter
 from .class_to_union import ClassToUnionExpressionConverter
 from .dict import DictComprehension
 from .different_class import DifferentClassExpressionConverter
-from .expression_converter import ExpressionConverter, map_expression
+from .expression_converter import ExpressionConverter, is_assignable, map_expression
 from .list import ListComprehension
 from .non_optional_to_optional import NonOptionalToOptionalExpressionConverter
 from .optional_to_optional import OptionalToOptionalExpressionConverter
@@ -14,6 +14,7 @@ from .union_to_union import UnionToUnionExpressionConverter
 __all__ = [
     "ExpressionConverter",
     "map_expression",
+    "is_assignable",
     "SameClassExpressionConverter",
     "DictComprehension",
     "ListComprehension",

--- a/dataclass_mapper/expression_converters/anything_to_any.py
+++ b/dataclass_mapper/expression_converters/anything_to_any.py
@@ -13,3 +13,6 @@ class AnythingToAnyExpressionConverter(ExpressionConverter):
         self, source: FieldType, target: FieldType, source_exp: Expression, recursion_depth: int
     ) -> Expression:
         return source_exp
+
+    def is_assignable(self, source: FieldType, target: FieldType) -> bool:
+        return isinstance(target, AnyFieldType)

--- a/dataclass_mapper/expression_converters/class_to_union.py
+++ b/dataclass_mapper/expression_converters/class_to_union.py
@@ -8,6 +8,7 @@ from .expression_converter import ExpressionConverter
 
 class ClassToUnionExpressionConverter(ExpressionConverter):
     def is_applicable_to_outer(self, source: FieldType, target: FieldType) -> bool:
+        # TODO: this could be better, what about ``list[int]`` to ``Union[list[int], ...]``
         return (
             isinstance(source, ClassFieldType) and isinstance(target, UnionFieldType) and source in target.inner_types
         )
@@ -16,3 +17,9 @@ class ClassToUnionExpressionConverter(ExpressionConverter):
         self, source: FieldType, target: FieldType, source_exp: Expression, recursion_depth: int
     ) -> Expression:
         return source_exp
+
+    def is_assignable(self, source: FieldType, target: FieldType) -> bool:
+        # TODO: this could be better, what about ``list[int]`` to ``Union[list[int], ...]``
+        return (
+            isinstance(source, ClassFieldType) and isinstance(target, UnionFieldType) and source in target.inner_types
+        )

--- a/dataclass_mapper/expression_converters/dict.py
+++ b/dataclass_mapper/expression_converters/dict.py
@@ -6,7 +6,7 @@ from dataclass_mapper.code_generator import (
 from dataclass_mapper.fieldtypes import FieldType
 from dataclass_mapper.fieldtypes.dict import DictFieldType
 
-from .expression_converter import ExpressionConverter, map_expression
+from .expression_converter import ExpressionConverter, is_assignable, map_expression
 
 
 class DictExpressionConverter(ExpressionConverter):
@@ -22,3 +22,11 @@ class DictExpressionConverter(ExpressionConverter):
         key_mapping_expression = map_expression(source.key_type, target.key_type, key_var, recursion_depth + 1)
         value_mapping_expression = map_expression(source.value_type, target.value_type, value_var, recursion_depth + 1)
         return DictComprehension(key_mapping_expression, value_mapping_expression, key_var, value_var, source_exp)
+
+    def is_assignable(self, source: FieldType, target: FieldType) -> bool:
+        return (
+            isinstance(source, DictFieldType)
+            and isinstance(target, DictFieldType)
+            and is_assignable(source.key_type, target.key_type)
+            and is_assignable(source.value_type, target.value_type)
+        )

--- a/dataclass_mapper/expression_converters/different_class.py
+++ b/dataclass_mapper/expression_converters/different_class.py
@@ -24,3 +24,6 @@ class DifferentClassExpressionConverter(ExpressionConverter):
         func_name = COLLECTION.create_func_name(source.cls_type, target.cls_type)
         function = DictLookup(Variable("COLLECTION"), Constant(func_name))
         return FunctionCall(function, [source_exp, extra_variable])
+
+    def is_assignable(self, source: FieldType, target: FieldType) -> bool:
+        return False

--- a/dataclass_mapper/expression_converters/expression_converter.py
+++ b/dataclass_mapper/expression_converters/expression_converter.py
@@ -24,6 +24,14 @@ class ExpressionConverter(ABC):
     ) -> Expression:
         """Creates the expression (that converts from source type to target type)."""
 
+    @abstractmethod
+    def is_assignable(self, source: FieldType, target: FieldType) -> bool:
+        """Essentially can you write ``target = source``.
+        The types can be slightly different, but should be assignable.
+        E.g. if target is of type ``Optional[FooBase]`` and ``source is of
+        type ``Foo`` (inheriting from ``FooBase``), it should return true.
+        """
+
 
 def map_expression(source: FieldType, target: FieldType, source_exp: Expression, recursion_depth: int) -> Expression:
     for expression_converter in ExpressionConverter.all_expression_converts:
@@ -31,3 +39,16 @@ def map_expression(source: FieldType, target: FieldType, source_exp: Expression,
             return expression_converter().map_expression(source, target, source_exp, recursion_depth)
 
     raise ConvertingNotPossibleError(source, target, recursion_depth)
+
+
+def is_assignable(source: FieldType, target: FieldType) -> bool:
+    """Essentially can you write ``target = source``.
+    The types can be slightly different, but should be assignable.
+    E.g. if target is of type ``Optional[FooBase]`` and ``source is of
+    type ``Foo`` (inheriting from ``FooBase``), it should return true.
+    """
+    for expression_converter in ExpressionConverter.all_expression_converts:
+        if expression_converter().is_assignable(source, target):
+            return True
+
+    return False

--- a/dataclass_mapper/expression_converters/list.py
+++ b/dataclass_mapper/expression_converters/list.py
@@ -2,7 +2,7 @@ from dataclass_mapper.code_generator import Expression, ListComprehension, Varia
 from dataclass_mapper.fieldtypes import FieldType
 from dataclass_mapper.fieldtypes.list import ListFieldType
 
-from .expression_converter import ExpressionConverter, map_expression
+from .expression_converter import ExpressionConverter, is_assignable, map_expression
 
 
 class ListExpressionConverter(ExpressionConverter):
@@ -16,3 +16,10 @@ class ListExpressionConverter(ExpressionConverter):
         iter_var = Variable(f"x{recursion_depth}")
         element_expression = map_expression(source.value_type, target.value_type, iter_var, recursion_depth + 1)
         return ListComprehension(element_expression, iter_var, source_exp)
+
+    def is_assignable(self, source: FieldType, target: FieldType) -> bool:
+        return (
+            isinstance(source, ListFieldType)
+            and isinstance(target, ListFieldType)
+            and is_assignable(source.value_type, source.value_type)
+        )

--- a/dataclass_mapper/expression_converters/non_optional_to_optional.py
+++ b/dataclass_mapper/expression_converters/non_optional_to_optional.py
@@ -1,7 +1,7 @@
 from dataclass_mapper.code_generator import Expression
 from dataclass_mapper.fieldtypes import FieldType, OptionalFieldType
 
-from .expression_converter import ExpressionConverter, map_expression
+from .expression_converter import ExpressionConverter, is_assignable, map_expression
 
 
 class NonOptionalToOptionalExpressionConverter(ExpressionConverter):
@@ -14,3 +14,10 @@ class NonOptionalToOptionalExpressionConverter(ExpressionConverter):
         assert isinstance(target, OptionalFieldType)
         recursive = map_expression(source, target.inner_type, source_exp, recusion_depth + 1)
         return recursive
+
+    def is_assignable(self, source: FieldType, target: FieldType) -> bool:
+        return (
+            not isinstance(source, OptionalFieldType)
+            and isinstance(target, OptionalFieldType)
+            and is_assignable(source, target.inner_type)
+        )

--- a/dataclass_mapper/expression_converters/optional_to_optional.py
+++ b/dataclass_mapper/expression_converters/optional_to_optional.py
@@ -1,7 +1,7 @@
 from dataclass_mapper.code_generator import NONE, Expression, TernaryOperator
 from dataclass_mapper.fieldtypes import FieldType, OptionalFieldType
 
-from .expression_converter import ExpressionConverter, map_expression
+from .expression_converter import ExpressionConverter, is_assignable, map_expression
 
 
 class OptionalToOptionalExpressionConverter(ExpressionConverter):
@@ -14,3 +14,10 @@ class OptionalToOptionalExpressionConverter(ExpressionConverter):
         assert isinstance(source, OptionalFieldType) and isinstance(target, OptionalFieldType)
         recursive = map_expression(source.inner_type, target.inner_type, source_exp, recusion_depth + 1)
         return TernaryOperator(source_exp.is_(NONE), NONE, recursive)
+
+    def is_assignable(self, source: FieldType, target: FieldType) -> bool:
+        return (
+            isinstance(source, OptionalFieldType)
+            and isinstance(target, OptionalFieldType)
+            and is_assignable(source.inner_type, target.inner_type)
+        )

--- a/dataclass_mapper/expression_converters/same_class.py
+++ b/dataclass_mapper/expression_converters/same_class.py
@@ -11,7 +11,7 @@ class SameClassExpressionConverter(ExpressionConverter):
         return (
             isinstance(source, ClassFieldType)
             and isinstance(target, ClassFieldType)
-            and source.cls_type is target.cls_type
+            and issubclass(source.cls_type, target.cls_type)
         ) or (
             isinstance(source, NotSupportedFieldType)
             and isinstance(target, NotSupportedFieldType)
@@ -22,3 +22,14 @@ class SameClassExpressionConverter(ExpressionConverter):
         self, source: FieldType, target: FieldType, source_exp: Expression, recursion_depth: int
     ) -> Expression:
         return source_exp
+
+    def is_assignable(self, source: FieldType, target: FieldType) -> bool:
+        return (
+            isinstance(source, ClassFieldType)
+            and isinstance(target, ClassFieldType)
+            and issubclass(source.cls_type, target.cls_type)
+        ) or (
+            isinstance(source, NotSupportedFieldType)
+            and isinstance(target, NotSupportedFieldType)
+            and source.type_ is target.type_
+        )

--- a/dataclass_mapper/expression_converters/set.py
+++ b/dataclass_mapper/expression_converters/set.py
@@ -1,7 +1,7 @@
 from dataclass_mapper.code_generator import Expression, SetComprehension, Variable
 from dataclass_mapper.fieldtypes import FieldType, SetFieldType
 
-from .expression_converter import ExpressionConverter, map_expression
+from .expression_converter import ExpressionConverter, is_assignable, map_expression
 
 
 class SetExpressionConverter(ExpressionConverter):
@@ -15,3 +15,10 @@ class SetExpressionConverter(ExpressionConverter):
         iter_var = Variable(f"x{recursion_depth}")
         element_expression = map_expression(source.value_type, target.value_type, iter_var, recursion_depth + 1)
         return SetComprehension(element_expression, iter_var, source_exp)
+
+    def is_assignable(self, source: FieldType, target: FieldType) -> bool:
+        return (
+            isinstance(source, SetFieldType)
+            and isinstance(target, SetFieldType)
+            and is_assignable(source.value_type, target.value_type)
+        )

--- a/dataclass_mapper/expression_converters/tuple.py
+++ b/dataclass_mapper/expression_converters/tuple.py
@@ -2,7 +2,7 @@ from dataclass_mapper.code_generator import Constant, DictLookup, Expression, Tu
 from dataclass_mapper.fieldtypes import FieldType
 from dataclass_mapper.fieldtypes.tuple import TupleFieldType
 
-from .expression_converter import ExpressionConverter, map_expression
+from .expression_converter import ExpressionConverter, is_assignable, map_expression
 
 
 class TupleExpressionConverter(ExpressionConverter):
@@ -22,4 +22,12 @@ class TupleExpressionConverter(ExpressionConverter):
                 map_expression(s, t, DictLookup(source_exp, Constant(i)), recursion_depth + 1)
                 for i, (s, t) in enumerate(zip(source.value_types, target.value_types))
             ]
+        )
+
+    def is_assignable(self, source: FieldType, target: FieldType) -> bool:
+        return (
+            isinstance(source, TupleFieldType)
+            and isinstance(target, TupleFieldType)
+            and len(source.value_types) == len(target.value_types)
+            and all(is_assignable(s, t) for s, t in zip(source.value_types, target.value_types))
         )

--- a/dataclass_mapper/expression_converters/union_to_union.py
+++ b/dataclass_mapper/expression_converters/union_to_union.py
@@ -17,3 +17,10 @@ class UnionToUnionExpressionConverter(ExpressionConverter):
         self, source: FieldType, target: FieldType, source_exp: Expression, recursion_depth: int
     ) -> Expression:
         return source_exp
+
+    def is_assignable(self, source: FieldType, target: FieldType) -> bool:
+        return (
+            isinstance(source, UnionFieldType)
+            and isinstance(target, UnionFieldType)
+            and all(source_subtype in target.inner_types for source_subtype in source.inner_types)
+        )

--- a/dataclass_mapper/fieldtypes/base.py
+++ b/dataclass_mapper/fieldtypes/base.py
@@ -12,7 +12,7 @@ class FieldType(ABC):
     @staticmethod
     @abstractmethod
     def is_applicable(type_: Any) -> bool:
-        pass
+        """Can the source type be converted to the target type"""
 
     @classmethod
     @abstractmethod

--- a/dataclass_mapper/fieldtypes/class_fieldtype.py
+++ b/dataclass_mapper/fieldtypes/class_fieldtype.py
@@ -1,5 +1,7 @@
 from typing import Any, cast, get_origin
 
+from dataclass_mapper.utils import get_class_name
+
 from .base import FieldType
 
 
@@ -16,10 +18,7 @@ class ClassFieldType(FieldType):
         return cls(type_)
 
     def __str__(self) -> str:
-        try:
-            return cast(str, self.cls_type.__name__)
-        except Exception:
-            return str(self.cls_type)
+        return get_class_name(self.cls_type)
 
     def __eq__(self, other: object) -> bool:
         if type(self) is not type(other):

--- a/dataclass_mapper/fieldtypes/not_supported.py
+++ b/dataclass_mapper/fieldtypes/not_supported.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import Any
 
+from dataclass_mapper.utils import get_class_name
+
 from .base import FieldType
 
 
@@ -17,4 +19,4 @@ class NotSupportedFieldType(FieldType):
         return NotSupportedFieldType(type_=type_)
 
     def __str__(self) -> str:
-        return str(self.type_)
+        return get_class_name(self.type_)

--- a/dataclass_mapper/mapper.py
+++ b/dataclass_mapper/mapper.py
@@ -99,7 +99,7 @@ def _make_mapper(
                     "as it has no default"
                 )
         elif callable(raw_source):
-            source_code.add_factory(target=target_field, source=raw_source)
+            source_code.add_factory(target=target_field, source=raw_source, namespace=namespace)
         else:
             raise AssertionError("impossible to reach")
 

--- a/dataclass_mapper/mapper.py
+++ b/dataclass_mapper/mapper.py
@@ -6,6 +6,7 @@ from importlib import import_module
 from typing import Any, Callable, Dict, Optional, Tuple, Type, TypeVar, Union, cast, overload
 
 from dataclass_mapper.implementations.simple_type import SimpleType
+from dataclass_mapper.utils import get_class_name
 
 from .classmeta import get_class_meta
 from .collection import COLLECTION
@@ -81,7 +82,7 @@ def _make_mapper(
         elif isinstance(raw_source, UpdateOnlyIfSet):
             if mapper_mode != MapperMode.UPDATE:
                 raise ValueError(
-                    f"'{target_field_name}' of '{target_cls.__name__}' cannot be set to update_only_if_set() "
+                    f"'{target_field_name}' of '{get_class_name(target_cls)}' cannot be set to update_only_if_set() "
                     f"if the mapper mode is not set to {MapperMode.UPDATE}."
                 )
             source_field_name = raw_source.field_name or target_field.attribute_name
@@ -95,8 +96,8 @@ def _make_mapper(
                 # leaving the target empty and using the default value/factory is not possible,
                 # as the target doesn't have a default value/factory
                 raise ValueError(
-                    f"'{target_field_name}' of '{target_cls.__name__}' cannot be set to {raw_source.created_via}, "
-                    "as it has no default"
+                    f"'{target_field_name}' of '{get_class_name(target_cls)}' cannot be set "
+                    f"to {raw_source.created_via}, as it has no default"
                 )
         elif callable(raw_source):
             source_code.add_factory(target=target_field, source=raw_source, namespace=namespace)
@@ -113,7 +114,8 @@ def _make_mapper(
 def get_source_field(source_field_name: str, source_fields: Dict[str, FieldMeta], source_cls: Any):
     if source_field_name not in source_fields:
         raise ValueError(
-            f"'{source_field_name}' of mapping in '{source_cls.__name__}' doesn't exist " f"in '{source_cls.__name__}'"
+            f"'{source_field_name}' of mapping in '{get_class_name(source_cls)}' doesn't exist "
+            f"in '{get_class_name(source_cls)}'"
         )
     return source_fields[source_field_name]
 
@@ -272,7 +274,7 @@ def add_specific_mapper_function(
     module = import_module(SourceCls.__module__)
 
     d: Dict = {}
-    filename = f"<{source_code_type.func_name}_{SourceCls.__name__}_{TargetCls.__name__}>"
+    filename = f"<{source_code_type.func_name}_{get_class_name(SourceCls)}_{get_class_name(TargetCls)}>"
     map_code = compile(map_code_ast, filename=filename, mode="exec")
     # Support older versions of python by calling {**a, **b} rather than a|b
     exec(map_code, {**module.__dict__, **context}, d)  # noqa: S102

--- a/dataclass_mapper/mapping_method.py
+++ b/dataclass_mapper/mapping_method.py
@@ -7,9 +7,12 @@ from uuid import uuid4
 
 from dataclass_mapper.exceptions import ConvertingNotPossibleError, UpdatingNotPossibleError
 from dataclass_mapper.expression_converters import map_expression
+from dataclass_mapper.fieldtypes.compute import compute_field_type
 from dataclass_mapper.fieldtypes.not_supported import NotSupportedFieldType
 from dataclass_mapper.mapper_mode import MapperMode
+from dataclass_mapper.namespace import Namespace
 from dataclass_mapper.update_expressions import map_update_expression
+from dataclass_mapper.utils import extract_function_types
 
 from . import code_generator as cg
 from .implementations.base import ClassMeta, FieldMeta
@@ -76,7 +79,7 @@ class MappingMethodSourceCode(ABC):
     def get_ast(self) -> ast.Module:
         pass
 
-    def add_factory(self, target: FieldMeta, source: Callable) -> None:
+    def add_factory(self, target: FieldMeta, source: Callable, namespace: Namespace) -> None:
         """Generate code for a factory mapping.
         The field will be assigned to the result of the function/method call.
         """
@@ -86,6 +89,24 @@ class MappingMethodSourceCode(ABC):
                 f"'{target.attribute_name}' of '{self.target_cls.name}' cannot be mapped "
                 "using a factory with more than one parameter"
             )
+
+        # if types from signature can be extracted, type check them
+        first_param_type, return_type = extract_function_types(source, namespace=namespace)
+        if first_param_type and not issubclass(self.source_cls.clazz, first_param_type):
+            raise TypeError(
+                f"The first parameter of the custom conversion function for field '{target.attribute_name}' "
+                f"of '{self.target_cls.name}' needs to be of type '{self.source_cls.name}' or a super type of it, "
+                f"but is of type '{first_param_type.__name__}'."
+            )
+
+        if return_type:
+            return_field_type = compute_field_type(return_type)
+            if return_field_type != target.type:
+                raise TypeError(
+                    f"The return value of the custom conversion function for field '{target.attribute_name}' "
+                    f"of '{self.target_cls.name}' needs to be of type '{target.type}', "
+                    f"but is of type '{return_type.__name__}'."
+                )
 
         factory_name = f"_{uuid4().hex}"
         self.factories[factory_name] = source

--- a/dataclass_mapper/mapping_method.py
+++ b/dataclass_mapper/mapping_method.py
@@ -6,7 +6,8 @@ from typing import Callable, Dict, List, Optional
 from uuid import uuid4
 
 from dataclass_mapper.exceptions import ConvertingNotPossibleError, UpdatingNotPossibleError
-from dataclass_mapper.expression_converters import map_expression
+from dataclass_mapper.expression_converters import is_assignable, map_expression
+from dataclass_mapper.fieldtypes.class_fieldtype import ClassFieldType
 from dataclass_mapper.fieldtypes.compute import compute_field_type
 from dataclass_mapper.fieldtypes.not_supported import NotSupportedFieldType
 from dataclass_mapper.mapper_mode import MapperMode
@@ -92,7 +93,8 @@ class MappingMethodSourceCode(ABC):
 
         # if types from signature can be extracted, type check them
         annotations = extract_function_types(source, namespace=namespace)
-        if annotations.first_param_type and not issubclass(self.source_cls.clazz, annotations.first_param_type):
+        first_param_type = compute_field_type(annotations.first_param_type)
+        if annotations.first_param_type and not is_assignable(ClassFieldType(self.source_cls.clazz), first_param_type):
             raise TypeError(
                 f"The first parameter of the custom conversion function for field '{target.attribute_name}' "
                 f"of '{self.target_cls.name}' needs to be of type '{self.source_cls.name}' or a super type of it, "
@@ -101,7 +103,7 @@ class MappingMethodSourceCode(ABC):
 
         if annotations.return_type:
             return_field_type = compute_field_type(annotations.return_type)
-            if return_field_type != target.type:
+            if not is_assignable(return_field_type, target.type):
                 raise TypeError(
                     f"The return value of the custom conversion function for field '{target.attribute_name}' "
                     f"of '{self.target_cls.name}' needs to be of type '{target.type}', "

--- a/dataclass_mapper/mapping_method.py
+++ b/dataclass_mapper/mapping_method.py
@@ -91,21 +91,21 @@ class MappingMethodSourceCode(ABC):
             )
 
         # if types from signature can be extracted, type check them
-        first_param_type, return_type = extract_function_types(source, namespace=namespace)
-        if first_param_type and not issubclass(self.source_cls.clazz, first_param_type):
+        annotations = extract_function_types(source, namespace=namespace)
+        if annotations.first_param_type and not issubclass(self.source_cls.clazz, annotations.first_param_type):
             raise TypeError(
                 f"The first parameter of the custom conversion function for field '{target.attribute_name}' "
                 f"of '{self.target_cls.name}' needs to be of type '{self.source_cls.name}' or a super type of it, "
-                f"but is of type '{first_param_type.__name__}'."
+                f"but is of type '{annotations.first_param_type.__name__}'."
             )
 
-        if return_type:
-            return_field_type = compute_field_type(return_type)
+        if annotations.return_type:
+            return_field_type = compute_field_type(annotations.return_type)
             if return_field_type != target.type:
                 raise TypeError(
                     f"The return value of the custom conversion function for field '{target.attribute_name}' "
                     f"of '{self.target_cls.name}' needs to be of type '{target.type}', "
-                    f"but is of type '{return_type.__name__}'."
+                    f"but is of type '{annotations.return_type.__name__}'."
                 )
 
         factory_name = f"_{uuid4().hex}"

--- a/dataclass_mapper/mapping_method.py
+++ b/dataclass_mapper/mapping_method.py
@@ -12,7 +12,7 @@ from dataclass_mapper.fieldtypes.not_supported import NotSupportedFieldType
 from dataclass_mapper.mapper_mode import MapperMode
 from dataclass_mapper.namespace import Namespace
 from dataclass_mapper.update_expressions import map_update_expression
-from dataclass_mapper.utils import extract_function_types
+from dataclass_mapper.utils import extract_function_types, get_class_name
 
 from . import code_generator as cg
 from .implementations.base import ClassMeta, FieldMeta
@@ -96,7 +96,7 @@ class MappingMethodSourceCode(ABC):
             raise TypeError(
                 f"The first parameter of the custom conversion function for field '{target.attribute_name}' "
                 f"of '{self.target_cls.name}' needs to be of type '{self.source_cls.name}' or a super type of it, "
-                f"but is of type '{annotations.first_param_type.__name__}'."
+                f"but is of type '{get_class_name(annotations.first_param_type)}'."
             )
 
         if annotations.return_type:
@@ -105,7 +105,7 @@ class MappingMethodSourceCode(ABC):
                 raise TypeError(
                     f"The return value of the custom conversion function for field '{target.attribute_name}' "
                     f"of '{self.target_cls.name}' needs to be of type '{target.type}', "
-                    f"but is of type '{annotations.return_type.__name__}'."
+                    f"but is of type '{get_class_name(annotations.return_type)}'."
                 )
 
         factory_name = f"_{uuid4().hex}"

--- a/dataclass_mapper/mapping_preparation.py
+++ b/dataclass_mapper/mapping_preparation.py
@@ -2,6 +2,8 @@ import warnings
 from copy import copy
 from typing import Any, Dict
 
+from dataclass_mapper.utils import get_class_name
+
 from .implementations.base import ClassMeta, FieldMeta
 from .implementations.sqlalchemy import InstrumentedAttribute, extract_instrumented_attribute_name_and_class
 from .special_field_mappings import (
@@ -40,13 +42,15 @@ def raise_if_mapping_doesnt_match_target(
     for target_field_name in actual_target_fields:
         if target_field_name not in mapping:
             raise ValueError(
-                f"'{target_field_name}' of '{target_cls.__name__}' has no mapping in '{source_cls.__name__}'"
+                f"'{target_field_name}' of '{get_class_name(target_cls)}' has no mapping "
+                f"in '{get_class_name(source_cls)}'"
             )
 
     for target_field_name in mapping:
         if target_field_name not in actual_target_fields:
             raise ValueError(
-                f"'{target_field_name}' of mapping in '{source_cls.__name__}' doesn't exist in '{target_cls.__name__}'"
+                f"'{target_field_name}' of mapping in '{get_class_name(source_cls)}' doesn't "
+                f"exist in '{get_class_name(target_cls)}'"
             )
 
 

--- a/dataclass_mapper/special_field_mappings.py
+++ b/dataclass_mapper/special_field_mappings.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Dict, Optional, Union
 
 from dataclass_mapper.implementations.sqlalchemy import InstrumentedAttribute
+from dataclass_mapper.utils import CallableWithMax1Parameter
 
 
 class Spezial(Enum):
@@ -63,9 +64,6 @@ def update_only_if_set(field_name: Optional[str] = None) -> UpdateOnlyIfSet:
     If the field name is not specified, it is assumed that the source field has the same name as the target field.
     """
     return UpdateOnlyIfSet(field_name)
-
-
-CallableWithMax1Parameter = Union[Callable[[], Any], Callable[[Any], Any]]
 
 
 # the different types that can be used as origin (source) for mapping to a member

--- a/dataclass_mapper/utils.py
+++ b/dataclass_mapper/utils.py
@@ -1,5 +1,10 @@
 import sys
-from typing import Any, Union, get_args, get_origin
+from inspect import isfunction, signature
+from typing import Any, Callable, Optional, Type, Union, get_args, get_origin, get_type_hints
+
+from dataclass_mapper.namespace import Namespace
+
+CallableWithMax1Parameter = Union[Callable[[], Any], Callable[[Any], Any]]
 
 
 def is_union_type(type_: Any) -> bool:
@@ -15,3 +20,27 @@ def is_union_type(type_: Any) -> bool:
 def is_optional(type_: Any) -> bool:
     # requires Python 3.8
     return is_union_type(type_) and type(None) in get_args(type_)
+
+
+def extract_function_types(
+    callable: CallableWithMax1Parameter, namespace: Optional[Namespace] = None
+) -> tuple[Optional[Type], Optional[Type]]:
+    """extracts the type of the only parameter (if there is one at all), and the type of the return value"""
+
+    if not isfunction(callable):
+        callable = callable.__call__
+
+    params = list(signature(callable).parameters.values())
+    type_hints = (
+        get_type_hints(callable, globalns=namespace.globals, localns=namespace.locals)
+        if namespace
+        else get_type_hints(callable)
+    )
+
+    return_type: Optional[Type] = type_hints.get("return")
+    first_param_type: Optional[Type] = None
+    if params:
+        first_param = params[0]
+        first_param_type = type_hints.get(first_param.name)
+
+    return first_param_type, return_type

--- a/dataclass_mapper/utils.py
+++ b/dataclass_mapper/utils.py
@@ -1,7 +1,7 @@
 import sys
 from dataclasses import dataclass
 from inspect import isfunction, signature
-from typing import Any, Callable, Optional, Type, Union, cast, get_args, get_origin, get_type_hints
+from typing import Any, Callable, Dict, Optional, Type, Union, cast, get_args, get_origin, get_type_hints
 
 from dataclass_mapper.namespace import Namespace
 
@@ -38,11 +38,15 @@ def extract_function_types(
         callable = callable.__call__  # type: ignore[operator]
 
     params = list(signature(callable).parameters.values())
-    type_hints = (
-        get_type_hints(callable, globalns=namespace.globals, localns=namespace.locals)
-        if namespace
-        else get_type_hints(callable)
-    )
+    type_hints: Dict[str, Any]
+    try:
+        type_hints = (
+            get_type_hints(callable, globalns=namespace.globals, localns=namespace.locals)
+            if namespace
+            else get_type_hints(callable)
+        )
+    except NameError:
+        type_hints = {}
 
     first_param_type: Optional[Type] = None
     if params:

--- a/dataclass_mapper/utils.py
+++ b/dataclass_mapper/utils.py
@@ -1,4 +1,5 @@
 import sys
+from dataclasses import dataclass
 from inspect import isfunction, signature
 from typing import Any, Callable, Optional, Type, Union, get_args, get_origin, get_type_hints
 
@@ -22,13 +23,19 @@ def is_optional(type_: Any) -> bool:
     return is_union_type(type_) and type(None) in get_args(type_)
 
 
+@dataclass
+class TypeAnnotation:
+    first_param_type: Optional[Type]
+    return_type: Optional[Type]
+
+
 def extract_function_types(
     callable: CallableWithMax1Parameter, namespace: Optional[Namespace] = None
-) -> tuple[Optional[Type], Optional[Type]]:
+) -> TypeAnnotation:
     """extracts the type of the only parameter (if there is one at all), and the type of the return value"""
 
     if not isfunction(callable):
-        callable = callable.__call__
+        callable = callable.__call__  # type: ignore[operator]
 
     params = list(signature(callable).parameters.values())
     type_hints = (
@@ -37,10 +44,10 @@ def extract_function_types(
         else get_type_hints(callable)
     )
 
-    return_type: Optional[Type] = type_hints.get("return")
     first_param_type: Optional[Type] = None
     if params:
         first_param = params[0]
         first_param_type = type_hints.get(first_param.name)
+    return_type: Optional[Type] = type_hints.get("return")
 
-    return first_param_type, return_type
+    return TypeAnnotation(first_param_type=first_param_type, return_type=return_type)

--- a/dataclass_mapper/utils.py
+++ b/dataclass_mapper/utils.py
@@ -1,7 +1,7 @@
 import sys
 from dataclasses import dataclass
 from inspect import isfunction, signature
-from typing import Any, Callable, Optional, Type, Union, get_args, get_origin, get_type_hints
+from typing import Any, Callable, Optional, Type, Union, cast, get_args, get_origin, get_type_hints
 
 from dataclass_mapper.namespace import Namespace
 
@@ -51,3 +51,10 @@ def extract_function_types(
     return_type: Optional[Type] = type_hints.get("return")
 
     return TypeAnnotation(first_param_type=first_param_type, return_type=return_type)
+
+
+def get_class_name(cls: Any) -> str:
+    try:
+        return cast(str, cls.__name__)
+    except AttributeError:
+        return str(cls)

--- a/docs/features/custom_conversion_function.rst
+++ b/docs/features/custom_conversion_function.rst
@@ -41,6 +41,8 @@ In case the function has one parameter, the source object will be passed and you
 In the second function ``compute_full_name`` takes one parameter ``contact: Contact``, and combines the ``first_name`` and ``surname`` into a string and initialize the field ``name`` with it.
 
 In case the function or callable object is annotated with types, the types will be checked.
+Teh first parameter (if specified) needs to be compatible with the type of the source class (could also be a super class, or an optional type).
+The return type needs to be compatible with the target field.
 E.g. if the function ``compute_full_name`` returns an ``int`` or takes the a parameter of type ``Person``, it will produce an ``TypeError`` during the creation of the mapper.
 
 .. warning::

--- a/docs/features/custom_conversion_function.rst
+++ b/docs/features/custom_conversion_function.rst
@@ -3,12 +3,15 @@
 Custom conversion functions
 ---------------------------
 
+It is possible to use a callable during a field mapping.
+That can be a function, a lambda, or a callable object.
+
 .. testsetup:: *
 
    >>> from dataclasses import dataclass, field
    >>> from enum import Enum, auto
    >>> from typing import List, Optional, Dict
-   >>> from dataclass_mapper import mapper, mapper_from, map_to, enum_mapper, enum_mapper_from, init_with_default, assume_not_none
+   >>> from dataclass_mapper import mapper, mapper_from, map_to, enum_mapper, enum_mapper_from, init_with_default, assume_not_none, create_mapper
 
 .. doctest::
 
@@ -17,24 +20,30 @@ Custom conversion functions
    ...     name: str
    ...     age: int
    >>>
-   >>> @mapper(Person, {"age": lambda: 45, "name": lambda self: f"{self.first_name} {self.surname}"})
-   ... @dataclass
+   >>> @dataclass
    ... class Contact:
    ...     surname: str
    ...     first_name: str
    >>>
+   >>> def compute_full_name(contact: Contact) -> str:
+   ...     return f"{contact.first_name} {contact.surname}"
+   >>>
+   >>> create_mapper(Contact, Person, {"age": lambda: 45, "name": compute_full_name})
+   >>> 
    >>> contact = Contact(first_name="Jesse", surname="Cross")
    >>> map_to(contact, Person)
    Person(name='Jesse Cross', age=45)
-
-It's possible to add custom functions to mappings.
 
 In case the function takes no arguments, the function just behaves like setting a constant.
 The first function ``lambda: 45`` has no parameters and just returns the constant ``45``, so the age will always be initialized with ``45``.
 
 In case the function has one parameter, the source object will be passed and you can initialize the field however you want.
-In the second function ``lambda self: f"{self.first_name} {self.surname}"`` there is one parameter ``self`` (resembling a class method), and it combines the ``first_name`` and ``surname`` into a string and initialize the field ``name`` with it.
+In the second function ``compute_full_name`` takes one parameter ``contact: Contact``, and combines the ``first_name`` and ``surname`` into a string and initialize the field ``name`` with it.
+
+In case the function or callable object is annotated with types, the types will be checked.
+E.g. if the function ``compute_full_name`` returns an ``int`` or takes the a parameter of type ``Person``, it will produce an ``TypeError`` during the creation of the mapper.
 
 .. warning::
-   Custom conversion functions are not type-checked.
-   So be careful when using them.
+   Always use typed functions or typed callable objects.
+   Untyped functions, untyped callable objects or just lambas (which cannot be types) will not by type-checked by the library.
+   Especially a lambda can return anything, and the library will not check the type during the conversion!

--- a/docs/type_safety.rst
+++ b/docs/type_safety.rst
@@ -9,7 +9,7 @@ All these checks already happen during the definition of the mapper, they are no
    >>> from dataclasses import dataclass
    >>> from enum import Enum, auto
    >>> from typing import Optional
-   >>> from dataclass_mapper import mapper, mapper_from, map_to, enum_mapper, enum_mapper_from, init_with_default
+   >>> from dataclass_mapper import mapper, mapper_from, map_to, enum_mapper, enum_mapper_from, init_with_default, create_mapper
 
 Missing fields check
 --------------------
@@ -122,3 +122,29 @@ The library cannot map the field ``full_time`` of type ``str`` to a ``bool``.
 
 Here the library complains about the mapping an optional field to an non-optional one.
 The other way around would be fine however.
+
+
+Type checks of custom conversion functions
+------------------------------------------
+
+   >>> @dataclass
+   ... class Contract:
+   ...     gross_salary: int
+   >>>
+   >>> @dataclass
+   ... class EmploymentAgreement:
+   ...     net_salary: int
+   >>>
+   >>> def compute_gross_salary(agreement: EmploymentAgreement) -> float:
+   ...    # returns a float instead of an expected int
+   ...    return agreement.net_salary * 1.5
+   >>>
+   >>> create_mapper(EmploymentAgreement, Contract, {"gross_salary": compute_gross_salary})
+   Traceback (most recent call last):
+       ...
+   TypeError: The return value of the custom conversion function for field 'gross_salary' of 'Contract' needs to be of type 'int', but is of type 'float'.
+
+.. warning::
+   Always use typed functions or typed callable objects.
+   Untyped functions, untyped callable objects or just lambas (which cannot be types) will not by type-checked by the library.
+   Especially a lambda can return anything, and the library will not check the type during the conversion!

--- a/tests/expression_converter/test_expression_converter.py
+++ b/tests/expression_converter/test_expression_converter.py
@@ -13,7 +13,12 @@ from tests.utils import assert_ast_equal
 
 
 @dataclass(frozen=True)
-class Foo:
+class FooBar:
+    pass
+
+
+@dataclass(frozen=True)
+class Foo(FooBar):
     pass
 
 
@@ -41,6 +46,16 @@ TEST_CASES: List[Scenario] = [
     Scenario(
         source=int_class_field_type,
         target=int_class_field_type,
+        expected_code="src.x",
+    ),
+    Scenario(
+        source=ClassFieldType(Foo),
+        target=ClassFieldType(Foo),
+        expected_code="src.x",
+    ),
+    Scenario(
+        source=ClassFieldType(Foo),
+        target=ClassFieldType(FooBar),
         expected_code="src.x",
     ),
     Scenario(

--- a/tests/fieldtypes/test_unusupported_fields.py
+++ b/tests/fieldtypes/test_unusupported_fields.py
@@ -1,3 +1,4 @@
+import sys
 from dataclasses import dataclass
 from typing import Generic, TypeVar
 
@@ -21,15 +22,19 @@ def test_dataclass_used_unsupported_fieldtype_raises_typeerror():
     class ClassWithSupportedType:
         value: int
 
+    expected_error_msg = "Field type 'SomeGeneric' is not supported."
+    if sys.version_info < (3, 10):
+        expected_error_msg = "Field type 'test_unusupported_fields.test_dataclass_used_unsupported_fieldtype_raises_typeerror.<locals>.SomeGeneric[int]' is not supported."  # noqa: E501
+
     with pytest.raises(TypeError) as excinfo:
         create_mapper(ClassWithUnsupportedType, ClassWithSupportedType)
 
-    assert str(excinfo.value) == "Field type 'SomeGeneric' is not supported."
+    assert str(excinfo.value) == expected_error_msg
 
     with pytest.raises(TypeError) as excinfo:
         create_mapper(ClassWithSupportedType, ClassWithUnsupportedType)
 
-    assert str(excinfo.value) == "Field type 'SomeGeneric' is not supported."
+    assert str(excinfo.value) == expected_error_msg
 
 
 def test_dataclass_used_unsupported_fieldtype_updates_raises_typeerror():
@@ -46,15 +51,19 @@ def test_dataclass_used_unsupported_fieldtype_updates_raises_typeerror():
     class ClassWithSupportedType:
         value: int
 
+    expected_error_msg = "Field type 'SomeGeneric' is not supported."
+    if sys.version_info < (3, 10):
+        expected_error_msg = "Field type 'test_unusupported_fields.test_dataclass_used_unsupported_fieldtype_updates_raises_typeerror.<locals>.SomeGeneric[int]' is not supported."  # noqa: E501
+
     with pytest.raises(TypeError) as excinfo:
         create_mapper(ClassWithUnsupportedType, ClassWithSupportedType, mapper_mode=MapperMode.UPDATE)
 
-    assert str(excinfo.value) == "Field type 'SomeGeneric' is not supported."
+    assert str(excinfo.value) == expected_error_msg
 
     with pytest.raises(TypeError) as excinfo:
         create_mapper(ClassWithSupportedType, ClassWithUnsupportedType, mapper_mode=MapperMode.UPDATE)
 
-    assert str(excinfo.value) == "Field type 'SomeGeneric' is not supported."
+    assert str(excinfo.value) == expected_error_msg
 
 
 def test_dataclass_unused_source_fields_are_ignored():

--- a/tests/fieldtypes/test_unusupported_fields.py
+++ b/tests/fieldtypes/test_unusupported_fields.py
@@ -24,12 +24,12 @@ def test_dataclass_used_unsupported_fieldtype_raises_typeerror():
     with pytest.raises(TypeError) as excinfo:
         create_mapper(ClassWithUnsupportedType, ClassWithSupportedType)
 
-    assert str(excinfo.value) == f"Field type '{SomeGeneric[int]}' is not supported."
+    assert str(excinfo.value) == "Field type 'SomeGeneric' is not supported."
 
     with pytest.raises(TypeError) as excinfo:
         create_mapper(ClassWithSupportedType, ClassWithUnsupportedType)
 
-    assert str(excinfo.value) == f"Field type '{SomeGeneric[int]}' is not supported."
+    assert str(excinfo.value) == "Field type 'SomeGeneric' is not supported."
 
 
 def test_dataclass_used_unsupported_fieldtype_updates_raises_typeerror():
@@ -49,12 +49,12 @@ def test_dataclass_used_unsupported_fieldtype_updates_raises_typeerror():
     with pytest.raises(TypeError) as excinfo:
         create_mapper(ClassWithUnsupportedType, ClassWithSupportedType, mapper_mode=MapperMode.UPDATE)
 
-    assert str(excinfo.value) == f"Field type '{SomeGeneric[int]}' is not supported."
+    assert str(excinfo.value) == "Field type 'SomeGeneric' is not supported."
 
     with pytest.raises(TypeError) as excinfo:
         create_mapper(ClassWithSupportedType, ClassWithUnsupportedType, mapper_mode=MapperMode.UPDATE)
 
-    assert str(excinfo.value) == f"Field type '{SomeGeneric[int]}' is not supported."
+    assert str(excinfo.value) == "Field type 'SomeGeneric' is not supported."
 
 
 def test_dataclass_unused_source_fields_are_ignored():

--- a/tests/test_default_factories.py
+++ b/tests/test_default_factories.py
@@ -1,3 +1,4 @@
+import sys
 from dataclasses import dataclass
 from typing import Generic, Optional, TypeVar
 
@@ -159,13 +160,14 @@ def test_function_with_wrong_unmappable_return_type_is_rejected():
     class Source:
         pass
 
+    expected_error_msg = "The return value of the custom conversion function for field 'x' of 'Target' needs to be of type 'int', but is of type 'G'."  # noqa: E501
+    if sys.version_info < (3, 10):
+        expected_error_msg = "The return value of the custom conversion function for field 'x' of 'Target' needs to be of type 'int', but is of type 'tests.test_default_factories.test_function_with_wrong_unmappable_return_type_is_rejected.<locals>.G[int]'."  # noqa: E501
+
     with pytest.raises(TypeError) as excinfo:
         create_mapper(Source, Target, {"x": func})
 
-    assert (
-        str(excinfo.value)
-        == "The return value of the custom conversion function for field 'x' of 'Target' needs to be of type 'int', but is of type 'G'."  # noqa: E501
-    )
+    assert str(excinfo.value) == expected_error_msg
 
 
 def test_function_with_param_supertype():
@@ -266,6 +268,21 @@ def test_function_with_optional_field():
         x: Optional[int]
 
     def func() -> int:
+        return 42
+
+    @dataclass
+    class Source:
+        pass
+
+    create_mapper(Source, Target, {"x": func})
+
+
+def test_function_with_optional_factory_param():
+    @dataclass
+    class Target:
+        x: int
+
+    def func(source: "Optional[Source]") -> int:
         return 42
 
     @dataclass

--- a/tests/test_default_factories.py
+++ b/tests/test_default_factories.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
+from typing import Generic, Optional, TypeVar
 
 import pytest
 
-from dataclass_mapper import map_to, mapper, mapper_from
+from dataclass_mapper import create_mapper, map_to, mapper, mapper_from
 
 
 def test_default_values_in_mapping():
@@ -67,3 +68,208 @@ def test_refuse_factory_with_multiple_parameters():
             pass
 
     assert str(excinfo.value) == "'x' of 'Target' cannot be mapped using a factory with more than one parameter"
+
+
+def test_function_with_types_are_accepted():
+    @dataclass
+    class Target:
+        x: int
+
+    def func() -> int:
+        return 42
+
+    @dataclass
+    class Source:
+        pass
+
+    create_mapper(Source, Target, {"x": func})
+
+
+def test_function_with_types_are_accepted_2():
+    @dataclass
+    class Target:
+        x: int
+
+    def func(x: "Source") -> int:
+        return 42
+
+    @dataclass
+    class Source:
+        pass
+
+    create_mapper(Source, Target, {"x": func})
+
+
+def test_function_with_wrong_param_type_is_rejected():
+    @dataclass
+    class Target:
+        x: int
+
+    def func(x: "str") -> int:
+        return 42
+
+    @dataclass
+    class Source:
+        pass
+
+    with pytest.raises(TypeError) as excinfo:
+        create_mapper(Source, Target, {"x": func})
+
+    assert (
+        str(excinfo.value)
+        == "The first parameter of the custom conversion function for field 'x' of 'Target' needs to be of type 'Source' or a super type of it, but is of type 'str'."  # noqa: E501
+    )
+
+
+def test_function_with_wrong_return_type_is_rejected():
+    @dataclass
+    class Target:
+        x: int
+
+    def func(x: "Source") -> None:
+        pass
+
+    @dataclass
+    class Source:
+        pass
+
+    with pytest.raises(TypeError) as excinfo:
+        create_mapper(Source, Target, {"x": func})
+
+    assert (
+        str(excinfo.value)
+        == "The return value of the custom conversion function for field 'x' of 'Target' needs to be of type 'int', but is of type 'NoneType'."  # noqa: E501
+    )
+
+
+def test_function_with_wrong_unmappable_return_type_is_rejected():
+    @dataclass
+    class Target:
+        x: int
+
+    T = TypeVar("T")
+
+    class G(Generic[T]):
+        pass
+
+    def func(x: "Source") -> "G[int]":
+        return G[int]()
+
+    @dataclass
+    class Source:
+        pass
+
+    with pytest.raises(TypeError) as excinfo:
+        create_mapper(Source, Target, {"x": func})
+
+    assert (
+        str(excinfo.value)
+        == "The return value of the custom conversion function for field 'x' of 'Target' needs to be of type 'int', but is of type 'G'."  # noqa: E501
+    )
+
+
+def test_function_with_param_supertype():
+    @dataclass
+    class Target:
+        x: int
+
+    def func(x: "SourceBase") -> int:
+        return 42
+
+    @dataclass
+    class SourceBase:
+        pass
+
+    @dataclass
+    class Source(SourceBase):
+        pass
+
+    create_mapper(Source, Target, {"x": func})
+
+
+def test_function_with_param_subtype_is_rejected():
+    @dataclass
+    class Target:
+        x: int
+
+    def func(x: "Source") -> int:
+        return 42
+
+    @dataclass
+    class SourceBase:
+        pass
+
+    @dataclass
+    class Source(SourceBase):
+        pass
+
+    with pytest.raises(TypeError) as excinfo:
+        create_mapper(SourceBase, Target, {"x": func})
+
+    assert (
+        str(excinfo.value)
+        == "The first parameter of the custom conversion function for field 'x' of 'Target' needs to be of type 'SourceBase' or a super type of it, but is of type 'Source'."  # noqa: E501
+    )
+
+
+def test_function_with_return_subtype():
+    class FooBase:
+        pass
+
+    class Foo(FooBase):
+        pass
+
+    @dataclass
+    class Target:
+        x: FooBase
+
+    def func(x: "Source") -> Foo:
+        return Foo()
+
+    @dataclass
+    class Source:
+        pass
+
+    create_mapper(Source, Target, {"x": func})
+
+
+def test_function_with_return_supertype_is_rejected():
+    class FooBase:
+        pass
+
+    class Foo(FooBase):
+        pass
+
+    @dataclass
+    class Target:
+        x: Foo
+
+    def func(x: "Source") -> FooBase:
+        return Foo()
+
+    @dataclass
+    class Source:
+        pass
+
+    with pytest.raises(TypeError) as excinfo:
+        create_mapper(Source, Target, {"x": func})
+
+    assert (
+        str(excinfo.value)
+        == "The return value of the custom conversion function for field 'x' of 'Target' needs to be of type 'Foo', but is of type 'FooBase'."  # noqa: E501
+    )
+
+
+def test_function_with_optional_field():
+    @dataclass
+    class Target:
+        x: Optional[int]
+
+    def func() -> int:
+        return 42
+
+    @dataclass
+    class Source:
+        pass
+
+    create_mapper(Source, Target, {"x": func})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,12 @@
 from dataclasses import dataclass
+from types import NoneType
 
 import pytest
 
 from dataclass_mapper.collection import COLLECTION
 from dataclass_mapper.mapper import create_mapper
+from dataclass_mapper.namespace import get_namespace
+from dataclass_mapper.utils import extract_function_types
 
 
 def test_is_mappable_to():
@@ -44,3 +47,66 @@ def test_naming_for_object_fails():
 
     with pytest.raises(TypeError):
         assert COLLECTION.get_update_code(5, 5)  # type: ignore[arg-type]
+
+
+def test_extract_function_types():
+    assert extract_function_types(lambda x: 42) == (None, None)
+
+    def only_param(x: int):
+        return 42
+
+    assert extract_function_types(only_param) == (int, None)
+
+    def only_return_type(x) -> int:
+        return 42
+
+    assert extract_function_types(only_return_type) == (None, int)
+
+    def both_param_and_return_type(x: float) -> str:
+        return "42"
+
+    assert extract_function_types(both_param_and_return_type) == (float, str)
+
+    def no_param() -> str:
+        return "42"
+
+    assert extract_function_types(no_param) == (None, str)
+
+    def distinguish_none_type(x: None) -> None:
+        pass
+
+    assert extract_function_types(distinguish_none_type) == (NoneType, NoneType)
+
+    def understand_string_annotations(x: "int") -> "str":
+        return "42"
+
+    assert extract_function_types(understand_string_annotations) == (int, str)
+
+    class Foo:
+        pass
+
+    def classes(x: "Foo") -> Foo:
+        return x
+
+    namespace = get_namespace(1)
+
+    assert extract_function_types(classes, namespace=namespace) == (Foo, Foo)
+
+    class CallableObject:
+        def __call__(self, x: int) -> str:
+            return "42"
+
+    assert extract_function_types(CallableObject()) == (int, str)
+
+    class CallableObjectWithoutParam:
+        def __call__(self) -> str:
+            return "42"
+
+    assert extract_function_types(CallableObjectWithoutParam()) == (None, str)
+
+    # TODO: check for bad annotations that are unparsable
+
+    # def bad_annotation(x: 1+1) -> "abcdef":
+    #     pass
+
+    # assert extract_function_types(bad_annotation) == (None, str)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,12 @@
+import sys
 from dataclasses import dataclass
-from types import NoneType
 
 import pytest
 
 from dataclass_mapper.collection import COLLECTION
 from dataclass_mapper.mapper import create_mapper
 from dataclass_mapper.namespace import get_namespace
-from dataclass_mapper.utils import extract_function_types
+from dataclass_mapper.utils import TypeAnnotation, extract_function_types
 
 
 def test_is_mappable_to():
@@ -50,37 +50,42 @@ def test_naming_for_object_fails():
 
 
 def test_extract_function_types():
-    assert extract_function_types(lambda x: 42) == (None, None)
+    assert extract_function_types(lambda x: 42) == TypeAnnotation(None, None)
 
     def only_param(x: int):
         return 42
 
-    assert extract_function_types(only_param) == (int, None)
+    assert extract_function_types(only_param) == TypeAnnotation(int, None)
 
     def only_return_type(x) -> int:
         return 42
 
-    assert extract_function_types(only_return_type) == (None, int)
+    assert extract_function_types(only_return_type) == TypeAnnotation(None, int)
 
     def both_param_and_return_type(x: float) -> str:
         return "42"
 
-    assert extract_function_types(both_param_and_return_type) == (float, str)
+    assert extract_function_types(both_param_and_return_type) == TypeAnnotation(float, str)
 
     def no_param() -> str:
         return "42"
 
-    assert extract_function_types(no_param) == (None, str)
+    assert extract_function_types(no_param) == TypeAnnotation(None, str)
 
     def distinguish_none_type(x: None) -> None:
         pass
 
-    assert extract_function_types(distinguish_none_type) == (NoneType, NoneType)
+    if sys.version_info < (3, 9):
+        NoneType = type(None)
+    else:
+        from types import NoneType
+
+    assert extract_function_types(distinguish_none_type) == TypeAnnotation(NoneType, NoneType)
 
     def understand_string_annotations(x: "int") -> "str":
         return "42"
 
-    assert extract_function_types(understand_string_annotations) == (int, str)
+    assert extract_function_types(understand_string_annotations) == TypeAnnotation(int, str)
 
     class Foo:
         pass
@@ -90,19 +95,19 @@ def test_extract_function_types():
 
     namespace = get_namespace(1)
 
-    assert extract_function_types(classes, namespace=namespace) == (Foo, Foo)
+    assert extract_function_types(classes, namespace=namespace) == TypeAnnotation(Foo, Foo)
 
     class CallableObject:
         def __call__(self, x: int) -> str:
             return "42"
 
-    assert extract_function_types(CallableObject()) == (int, str)
+    assert extract_function_types(CallableObject()) == TypeAnnotation(int, str)
 
     class CallableObjectWithoutParam:
         def __call__(self) -> str:
             return "42"
 
-    assert extract_function_types(CallableObjectWithoutParam()) == (None, str)
+    assert extract_function_types(CallableObjectWithoutParam()) == TypeAnnotation(None, str)
 
     # TODO: check for bad annotations that are unparsable
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -109,9 +109,7 @@ def test_extract_function_types():
 
     assert extract_function_types(CallableObjectWithoutParam()) == TypeAnnotation(None, str)
 
-    # TODO: check for bad annotations that are unparsable
+    def bad_annotation(x: 1 + 1) -> "abcdef":  # type: ignore # noqa: F821
+        pass
 
-    # def bad_annotation(x: 1+1) -> "abcdef":
-    #     pass
-
-    # assert extract_function_types(bad_annotation) == (None, str)
+    assert extract_function_types(bad_annotation) == TypeAnnotation(None, None)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -75,7 +75,7 @@ def test_extract_function_types():
     def distinguish_none_type(x: None) -> None:
         pass
 
-    if sys.version_info < (3, 9):
+    if sys.version_info < (3, 10):
         NoneType = type(None)
     else:
         from types import NoneType


### PR DESCRIPTION
Todos:

- [x] sub/super class of return type
- [x] what if the annotation is bad (e.g. `def foo(x: 1+1) -> 2+3: pass`)
- [x] in general, allow mapping a subtype to a super type field
- [x] allow super type param `def foo(source: Optional[SouceBase]) -> FieldType: `
- [x] Container types (invariant?, covariant, controvariant)?
(don't think it matters too much)